### PR TITLE
Implemented Get Suggestions Screen with LocationSearch API

### DIFF
--- a/client/src/navio.tsx
+++ b/client/src/navio.tsx
@@ -7,6 +7,7 @@ import {PlaygroundExpoImage} from '@app/screens/playground/expo-image';
 import {Settings} from '@app/screens/settings';
 import {Example} from '@app/screens/_screen-sample';
 import {MyItineraries} from './screens/myitineraries';
+import { GetSuggestions } from './screens/getsuggestions';
 
 import {useAppearance} from '@app/utils/hooks';
 import {
@@ -27,6 +28,7 @@ export const navio = Navio.build({
     Example,
 
     MyItineraries,
+    GetSuggestions,
 
     Playground,
     PlaygroundFlashList,
@@ -45,7 +47,7 @@ export const navio = Navio.build({
     AuthSignup
   },
   stacks: {
-    MainStack: ['Main', 'Example'],
+    MainStack: ['Main', 'Example', 'GetSuggestions'],
     MyItinerariesStack:['MyItineraries'],
     ExampleStack: {
       screens: ['Example'],

--- a/client/src/screens/getsuggestions.tsx
+++ b/client/src/screens/getsuggestions.tsx
@@ -1,42 +1,55 @@
-import React, { useState } from 'react';
-import { ScrollView, TextInput, Modal, TouchableOpacity } from 'react-native';
-import { Text, View, Button, Checkbox } from 'react-native-ui-lib';
-import { observer } from 'mobx-react';
-import { NavioScreen } from 'rn-navio';
-import { services, useServices } from '@app/services';
-import { useAppearance } from '@app/utils/hooks';
+import React, { useEffect, useState } from "react";
+import { ScrollView, StyleSheet, TextInput, Alert, Modal } from "react-native";
+import { Text, View, Colors, Button, Checkbox } from "react-native-ui-lib";
+import { observer } from "mobx-react";
+import { NavioScreen } from "rn-navio";
+import { services, useServices } from "@app/services";
+import { useAppearance } from "@app/utils/hooks";
+import { LocationSearchApi } from "@app/services/api/locationsearch";
 
 export const GetSuggestions: NavioScreen = observer(() => {
   useAppearance();
   const { t, navio } = useServices();
 
-  const [location, setLocation] = useState('');
+  const [location, setLocation] = useState("");
   const [selectedRecreation, setSelectedRecreation] = useState<string[]>([]);
   const [selectedDiner, setSelectedDiner] = useState<string[]>([]);
   const [showRecreationModal, setShowRecreationModal] = useState(false);
   const [showDinerModal, setShowDinerModal] = useState(false);
+  const [suggestions, setSuggestions] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
 
-  const recreationOptions = [
-    'Wildlife', 'Adventure', 'Beaches', 'Museums', 'Hiking', 'Parks'
-  ];
-  const dinerOptions = [
-    'Fast Food', 'Fine Dining', 'Cafés', 'Buffets', 'Local Cuisine'
-  ];
+  const recreationOptions = ["Wildlife", "Adventure", "Beaches", "Museums", "Hiking", "Parks"];
+  const dinerOptions = ["Fast Food", "Fine Dining", "Cafés", "Buffets", "Local Cuisine"];
 
-  const toggleSelection = (item: string, type: 'recreation' | 'diner') => {
-    if (type === 'recreation') {
-      setSelectedRecreation(prev => 
-        prev.includes(item) ? prev.filter(i => i !== item) : [...prev, item]
-      );
+  const toggleSelection = (item: string, type: "recreation" | "diner") => {
+    if (type === "recreation") {
+      setSelectedRecreation(prev => prev.includes(item) ? prev.filter(i => i !== item) : [...prev, item]);
     } else {
-      setSelectedDiner(prev => 
-        prev.includes(item) ? prev.filter(i => i !== item) : [...prev, item]
-      );
+      setSelectedDiner(prev => prev.includes(item) ? prev.filter(i => i !== item) : [...prev, item]);
+    }
+  };
+
+  const fetchSuggestions = async () => {
+    if (!location.trim()) {
+      Alert.alert("Error", "Please enter a location.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const searchQuery = [location, ...selectedRecreation, ...selectedDiner].join(", ");
+      const data = await LocationSearchApi.search(searchQuery, "attractions");
+      setSuggestions(data?.data || []);
+    } catch (error) {
+      console.error("Error fetching suggestions:", error);
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
-    <View flex bg-bgColor padding-s4>
+    <View flex bg-bgColor padding-s3>
       <ScrollView contentInsetAdjustmentBehavior="always">
         <Text text50 marginB-s2>Get Suggestions</Text>
         <TextInput 
@@ -45,10 +58,16 @@ export const GetSuggestions: NavioScreen = observer(() => {
           onChangeText={setLocation}
           style={{ borderWidth: 1, borderColor: '#ccc', borderRadius: 8, padding: 10, marginBottom: 10 }}
         />
-        
-        <Button label="Accommodation" marginB-s2 onPress={() => {}} />
         <Button label="Recreation" marginB-s2 onPress={() => setShowRecreationModal(true)} />
-        <Button label="Diner" onPress={() => setShowDinerModal(true)} />
+        <Button label="Diner" marginB-s2 onPress={() => setShowDinerModal(true)} />
+        <Button label="Get Suggestions" onPress={fetchSuggestions} marginB-s2 disabled={loading} />
+        {loading ? (
+          <Text text70M>Loading suggestions...</Text>
+        ) : (
+          suggestions.map((item, index) => (
+            <Text key={index} text70M>{item.name}</Text>
+          ))
+        )}
       </ScrollView>
 
       {/* Recreation Modal */}
@@ -63,7 +82,7 @@ export const GetSuggestions: NavioScreen = observer(() => {
               onValueChange={() => toggleSelection(option, 'recreation')} 
             />
           ))}
-          <Button label="Close" marginT-s4 onPress={() => setShowRecreationModal(false)} />
+          <Button label="Submit" marginT-s4 onPress={() => setShowRecreationModal(false)} />
         </View>
       </Modal>
 
@@ -79,7 +98,7 @@ export const GetSuggestions: NavioScreen = observer(() => {
               onValueChange={() => toggleSelection(option, 'diner')} 
             />
           ))}
-          <Button label="Close" marginT-s4 onPress={() => setShowDinerModal(false)} />
+          <Button label="Submit" marginT-s4 onPress={() => setShowDinerModal(false)} />
         </View>
       </Modal>
     </View>
@@ -87,5 +106,5 @@ export const GetSuggestions: NavioScreen = observer(() => {
 });
 
 GetSuggestions.options = {
-  title: 'Get Suggestions',
+  title: "Get Suggestions",
 };

--- a/client/src/screens/getsuggestions.tsx
+++ b/client/src/screens/getsuggestions.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import { ScrollView, TextInput, Modal, TouchableOpacity } from 'react-native';
+import { Text, View, Button, Checkbox } from 'react-native-ui-lib';
+import { observer } from 'mobx-react';
+import { NavioScreen } from 'rn-navio';
+import { services, useServices } from '@app/services';
+import { useAppearance } from '@app/utils/hooks';
+
+export const GetSuggestions: NavioScreen = observer(() => {
+  useAppearance();
+  const { t, navio } = useServices();
+
+  const [location, setLocation] = useState('');
+  const [selectedRecreation, setSelectedRecreation] = useState<string[]>([]);
+  const [selectedDiner, setSelectedDiner] = useState<string[]>([]);
+  const [showRecreationModal, setShowRecreationModal] = useState(false);
+  const [showDinerModal, setShowDinerModal] = useState(false);
+
+  const recreationOptions = [
+    'Wildlife', 'Adventure', 'Beaches', 'Museums', 'Hiking', 'Parks'
+  ];
+  const dinerOptions = [
+    'Fast Food', 'Fine Dining', 'Cafés', 'Buffets', 'Local Cuisine'
+  ];
+
+  const toggleSelection = (item: string, type: 'recreation' | 'diner') => {
+    if (type === 'recreation') {
+      setSelectedRecreation(prev => 
+        prev.includes(item) ? prev.filter(i => i !== item) : [...prev, item]
+      );
+    } else {
+      setSelectedDiner(prev => 
+        prev.includes(item) ? prev.filter(i => i !== item) : [...prev, item]
+      );
+    }
+  };
+
+  return (
+    <View flex bg-bgColor padding-s4>
+      <ScrollView contentInsetAdjustmentBehavior="always">
+        <Text text50 marginB-s2>Get Suggestions</Text>
+        <TextInput 
+          placeholder="Enter location"
+          value={location}
+          onChangeText={setLocation}
+          style={{ borderWidth: 1, borderColor: '#ccc', borderRadius: 8, padding: 10, marginBottom: 10 }}
+        />
+        
+        <Button label="Accommodation" marginB-s2 onPress={() => {}} />
+        <Button label="Recreation" marginB-s2 onPress={() => setShowRecreationModal(true)} />
+        <Button label="Diner" onPress={() => setShowDinerModal(true)} />
+      </ScrollView>
+
+      {/* Recreation Modal */}
+      <Modal visible={showRecreationModal} animationType="slide" transparent>
+        <View flex center bg-white padding-s4>
+          <Text text60 marginB-s2>Choose Recreation Types</Text>
+          {recreationOptions.map(option => (
+            <Checkbox 
+              key={option} 
+              label={option} 
+              value={selectedRecreation.includes(option)} 
+              onValueChange={() => toggleSelection(option, 'recreation')} 
+            />
+          ))}
+          <Button label="Close" marginT-s4 onPress={() => setShowRecreationModal(false)} />
+        </View>
+      </Modal>
+
+      {/* Diner Modal */}
+      <Modal visible={showDinerModal} animationType="slide" transparent>
+        <View flex center bg-white padding-s4>
+          <Text text60 marginB-s2>Choose Diner Types</Text>
+          {dinerOptions.map(option => (
+            <Checkbox 
+              key={option} 
+              label={option} 
+              value={selectedDiner.includes(option)} 
+              onValueChange={() => toggleSelection(option, 'diner')} 
+            />
+          ))}
+          <Button label="Close" marginT-s4 onPress={() => setShowDinerModal(false)} />
+        </View>
+      </Modal>
+    </View>
+  );
+});
+
+GetSuggestions.options = {
+  title: 'Get Suggestions',
+};

--- a/client/src/screens/main.tsx
+++ b/client/src/screens/main.tsx
@@ -1,54 +1,54 @@
-import React, {useEffect} from 'react';
-import {ScrollView} from 'react-native';
-import {Text, View} from 'react-native-ui-lib';
-import {observer} from 'mobx-react';
-import {NavioScreen} from 'rn-navio';
+import React, { useEffect } from "react";
+import { ScrollView } from "react-native";
+import { Text, View, Button } from "react-native-ui-lib";
+import { observer } from "mobx-react";
+import { NavioScreen } from "rn-navio";
 
-import {services, useServices} from '@app/services';
-import {useAppearance} from '@app/utils/hooks';
-import {NavioSection} from '@app/components/sections/NavioSection';
-import { SplashBanner } from '../components/splash-banner';
-import { ItineraryTracker } from '../components/itinerary-tracker';
+import { services, useServices } from "@app/services";
+import { useAppearance } from "@app/utils/hooks";
+import { SplashBanner } from "../components/splash-banner";
+import { ItineraryTracker } from "../components/itinerary-tracker";
 
 export type Params = {
-  type?: 'push' | 'show';
+  type?: "push" | "show";
   productId?: string;
 };
 
 export const Main: NavioScreen = observer(() => {
   useAppearance(); // for Dark Mode
-  const {t, navio} = useServices();
+  const { t, navio } = useServices();
   const navigation = navio.useN();
   const params = navio.useParams<Params>();
-  // const {ui} = useStores();
-
-  // State
-
-  // Methods
 
   // Start
   useEffect(() => {
     configureUI();
   }, []);
 
-  // UI Methods
   const configureUI = () => {
     navigation.setOptions({});
   };
-
-  // UI Methods
 
   return (
     <View flex bg-white>
       <ScrollView contentInsetAdjustmentBehavior="always">
         <SplashBanner />
-
         <ItineraryTracker />
       </ScrollView>
+
+      {/* Get Suggestions Button */}
+      <View padding-20>
+        <Button
+          label="Get Suggestions"
+          onPress={() => navio.push("GetSuggestions")}
+          backgroundColor="#007AFF"
+          color="white"
+        />
+      </View>
     </View>
   );
 });
 
-Main.options = props => ({
+Main.options = (props) => ({
   title: ``,
 });

--- a/client/src/services/api/locationsearch.ts
+++ b/client/src/services/api/locationsearch.ts
@@ -1,0 +1,65 @@
+import { supabase } from "@app/lib/supabase"; // Supabase client
+import { TRIPADVISOR_API_KEY } from "@env"; // API Key from .env
+
+const CACHE_EXPIRATION_HOURS = 24; // Adjust as needed
+
+// Function to check the cache and fetch from API if needed
+export async function getLocation(searchQuery: string) {
+  // Step 1: Check if data exists in Supabase and is still fresh
+  const { data: cachedData, error } = await supabase
+    .from("locations_search_cache")
+    .select("*")
+    .eq("name", searchQuery)
+    .gte("last_updated", new Date(Date.now() - CACHE_EXPIRATION_HOURS * 60 * 60 * 1000).toISOString()) // Check if it's fresh
+    .single();
+
+  if (error && error.code !== "PGRST116") {
+    console.error("Supabase error:", error);
+  }
+
+  if (cachedData) {
+    console.log("Using cached data:", cachedData);
+    return cachedData; // Use cached data
+  }
+
+  // Step 2: Fetch from Tripadvisor API if not cached or expired
+  const url = `https://api.content.tripadvisor.com/api/v1/location/search?key=${TRIPADVISOR_API_KEY}&searchQuery=${encodeURIComponent(searchQuery)}&language=en`;
+
+  try {
+    const response = await fetch(url, { method: "GET", headers: { accept: "application/json" } });
+    const apiData = await response.json();
+
+    if (!apiData || !apiData.data || apiData.data.length === 0) {
+      throw new Error("No results found");
+    }
+
+    // Extract the first result (assuming most relevant)
+    const location = apiData.data[0];
+
+    // Step 3: Save new data to Supabase
+    const { error: insertError } = await supabase.from("location_search_cache").upsert(
+      {
+        location_id: location.location_id,
+        name: location.name,
+        street1: location.address_obj?.street1 || null,
+        street2: location.address_obj?.street2 || null,
+        city: location.address_obj?.city || null,
+        state: location.address_obj?.state || null,
+        country: location.address_obj?.country || null,
+        postalcode: location.address_obj?.postalcode || null,
+        address_string: location.address_obj?.address_string || null,
+        last_updated: new Date().toISOString(),
+      },
+      { onConflict: ["location_id"] } // Prevent duplicates
+    );
+
+    if (insertError) {
+      console.error("Error saving to cache:", insertError);
+    }
+
+    return location; // Return fresh data
+  } catch (error) {
+    console.error("API fetch error:", error);
+    throw error;
+  }
+}

--- a/client/src/services/api/locationsearch.ts
+++ b/client/src/services/api/locationsearch.ts
@@ -1,65 +1,30 @@
-import { supabase } from "@app/lib/supabase"; // Supabase client
-import { TRIPADVISOR_API_KEY } from "@env"; // API Key from .env
+import { Alert } from "react-native";
+import { TRIPADVISOR_API_KEY } from "@env";
 
-const CACHE_EXPIRATION_HOURS = 24; // Adjust as needed
+export const LocationSearchApi = {
+  search: async (query: string, category?: string) => {
+    try {
+      const url = new URL("https://api.content.tripadvisor.com/api/v1/location/search");
+      url.searchParams.append("key", TRIPADVISOR_API_KEY);
+      url.searchParams.append("searchQuery", encodeURIComponent(query));
+      if (category) url.searchParams.append("category", category);
+      url.searchParams.append("language", "en");
 
-// Function to check the cache and fetch from API if needed
-export async function getLocation(searchQuery: string) {
-  // Step 1: Check if data exists in Supabase and is still fresh
-  const { data: cachedData, error } = await supabase
-    .from("locations_search_cache")
-    .select("*")
-    .eq("name", searchQuery)
-    .gte("last_updated", new Date(Date.now() - CACHE_EXPIRATION_HOURS * 60 * 60 * 1000).toISOString()) // Check if it's fresh
-    .single();
+      const response = await fetch(url.toString(), {
+        method: "GET",
+        headers: { accept: "application/json" },
+      });
 
-  if (error && error.code !== "PGRST116") {
-    console.error("Supabase error:", error);
-  }
+      if (!response.ok) {
+        throw new Error(`API Error: ${response.status}`);
+      }
 
-  if (cachedData) {
-    console.log("Using cached data:", cachedData);
-    return cachedData; // Use cached data
-  }
-
-  // Step 2: Fetch from Tripadvisor API if not cached or expired
-  const url = `https://api.content.tripadvisor.com/api/v1/location/search?key=${TRIPADVISOR_API_KEY}&searchQuery=${encodeURIComponent(searchQuery)}&language=en`;
-
-  try {
-    const response = await fetch(url, { method: "GET", headers: { accept: "application/json" } });
-    const apiData = await response.json();
-
-    if (!apiData || !apiData.data || apiData.data.length === 0) {
-      throw new Error("No results found");
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      console.error("Error fetching location data:", error);
+      Alert.alert("Error", "Failed to fetch locations. Please try again.");
+      return null;
     }
-
-    // Extract the first result (assuming most relevant)
-    const location = apiData.data[0];
-
-    // Step 3: Save new data to Supabase
-    const { error: insertError } = await supabase.from("location_search_cache").upsert(
-      {
-        location_id: location.location_id,
-        name: location.name,
-        street1: location.address_obj?.street1 || null,
-        street2: location.address_obj?.street2 || null,
-        city: location.address_obj?.city || null,
-        state: location.address_obj?.state || null,
-        country: location.address_obj?.country || null,
-        postalcode: location.address_obj?.postalcode || null,
-        address_string: location.address_obj?.address_string || null,
-        last_updated: new Date().toISOString(),
-      },
-      { onConflict: ["location_id"] } // Prevent duplicates
-    );
-
-    if (insertError) {
-      console.error("Error saving to cache:", insertError);
-    }
-
-    return location; // Return fresh data
-  } catch (error) {
-    console.error("API fetch error:", error);
-    throw error;
-  }
-}
+  },
+};

--- a/client/types/env.d.ts
+++ b/client/types/env.d.ts
@@ -1,4 +1,5 @@
 declare module '@env' {
   export const SUPABASE_URL: string;
-  export const SUPABASE_ANON_KEY: string;  
+  export const SUPABASE_ANON_KEY: string;
+  export const TRIPADVISOR_API_KEY: string;
 }


### PR DESCRIPTION
- Added the Get Suggestions screen and integrated it into navigation.

- Added Get Suggestions Button in Main Screen that navigates to the Get Suggestions Screen

- Didn't Include Accomodation suggestions yet because I dont know how to do the date thingy pa

- Implemented LocationSearch request to fetch location-based suggestions from TripAdvisor.

- Users can enter a location and select Recreation and Diner options to refine search results.

- The selected filters are included in the searchQuery parameter for accurate suggestions.

- Displays fetched suggestions on the screen text only for now I need to implement the caching pa. Initially planned to show photo sa suggestions but the Location Search doesnt include photo. 

This is a sample response sa location search

{
      "location_id": "1475801",
      "name": "Ayala Center Cebu",
      "address_obj": {
        "street1": "Archbishop Reyes Avenue",
        "street2": "Cardinal Rosales Avenue",
        "city": "Cebu City",
        "state": "Cebu Island",
        "country": "Visayas",
        "postalcode": "6000",
        "address_string": "Archbishop Reyes Avenue Cardinal Rosales Avenue, Cebu City 6000 Philippines"
      }

to get photos and reviews and more details i need to implement pa Location Details request which is mao ang next thing ako buhaton

- Includes error handling and loading indicators.