### PR TITLE
[Feature][Cram] Integrated react native maps for get suggestions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,7 @@
     "@react-native-async-storage/async-storage": "^2.1.1",
     "@react-native-community/datetimepicker": "7.7.0",
     "@react-native-community/masked-view": "^0.1.11",
-    "@react-native-picker/picker": "2.6.1",
+    "@react-native-picker/picker": "^2.11.0",
     "@react-navigation/bottom-tabs": "^6.4.0",
     "@react-navigation/drawer": "^6.5.8",
     "@react-navigation/native": "^6.0.13",

--- a/client/package.json
+++ b/client/package.json
@@ -60,6 +60,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.73.6",
     "react-native-gesture-handler": "~2.14.0",
+    "react-native-maps": "^1.20.1",
     "react-native-mmkv": "^2.7.0",
     "react-native-reanimated": "~3.6.2",
     "react-native-safe-area-context": "4.8.2",

--- a/client/src/screens/getsuggestions.tsx
+++ b/client/src/screens/getsuggestions.tsx
@@ -45,10 +45,10 @@ export const GetSuggestions: NavioScreen = observer(() => {
       return;
     }
 
-  if (!selectedLocation) {
-    Alert.alert("Error", "Please select a location on the map.");
-    return;
-  }
+    if (!selectedLocation) {
+      Alert.alert("Error", "Please select a location on the map.");
+      return;
+    }
 
     setLoading(true);
     try {
@@ -58,12 +58,18 @@ export const GetSuggestions: NavioScreen = observer(() => {
         return;
       }
 
-      const { fullAddress } = geocodeResult;
+      const { fullAddress, route, city, country } = geocodeResult;
 
-      // Dynamically choose category based on selected option (Recreation or Diner)
-      const category = selectedOption === "recreation" ? "recreation" : "diner";
-      const filters = selectedOption === "recreation" ? selectedRecreation : selectedDiner;
-      const query = `${fullAddress} ${filters.join(", ")}`;
+      // Dynamically set the category based on selected option
+      let category = "";
+      if (selectedOption === "recreation") {
+        category = "attractions"; // Recreation -> Attractions
+      } else if (selectedOption === "diner") {
+        category = "restaurants"; // Diner -> Restaurants
+      }
+
+      // Combine route, city, and country for the query
+      const query = `${route}, ${city}, ${country} ${selectedOption === "recreation" ? selectedRecreation.join(", ") : selectedDiner.join(", ")}`;
 
       const data = await LocationSearchApi.search(query, category); // Pass category dynamically
       const results = data?.data || [];

--- a/client/src/screens/getsuggestions.tsx
+++ b/client/src/screens/getsuggestions.tsx
@@ -3,8 +3,7 @@ import { ScrollView, StyleSheet, TextInput, Alert, Modal, Linking, TouchableOpac
 import { Text, View, Colors, Button, Checkbox } from "react-native-ui-lib";
 import { observer } from "mobx-react";
 import { NavioScreen } from "rn-navio";
-import { services, useServices } from "@app/services";
-import { useAppearance } from "@app/utils/hooks";
+import { useServices } from "@app/services";
 import { LocationSearchApi } from "@app/services/api/locationsearch";
 import { LocationDetailsApi } from "@app/services/api/locationdetails";
 

--- a/client/src/screens/getsuggestions.tsx
+++ b/client/src/screens/getsuggestions.tsx
@@ -17,18 +17,14 @@ type Location = {
 };
 
 export const GetSuggestions: NavioScreen = observer(() => {
-  useAppearance();
   const { t, navio } = useServices();
 
   const [location, setLocation] = useState("");
   const [selectedOption, setSelectedOption] = useState<string>(""); // Recreation or Diner
   const [selectedRecreation, setSelectedRecreation] = useState<string[]>([]);
   const [selectedDiner, setSelectedDiner] = useState<string[]>([]);
-  const [showRecreationModal, setShowRecreationModal] = useState(false);
-  const [showDinerModal, setShowDinerModal] = useState(false);
   const [suggestions, setSuggestions] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
-
   const [selectedLocation, setSelectedLocation] = useState<Location | null>(null);
 
   const recreationOptions = ["Wildlife", "Adventure", "Beaches", "Museums", "Hiking", "Parks"];
@@ -53,7 +49,10 @@ export const GetSuggestions: NavioScreen = observer(() => {
       const filters = selectedOption === "recreation" ? selectedRecreation : selectedDiner;
       const query = `${location} ${filters.join(", ")}`;
 
-      const data = await LocationSearchApi.search(query, "attractions");
+      // Dynamically choose category based on selected option (Recreation or Diner)
+      const category = selectedOption === "recreation" ? "recreation" : "diner";
+
+      const data = await LocationSearchApi.search(query, category); // Pass category dynamically
       const results = data?.data || [];
 
       const detailedResults = await Promise.all(

--- a/client/src/services/api/geocoding.ts
+++ b/client/src/services/api/geocoding.ts
@@ -36,11 +36,15 @@ export const GeocodingApi = {
         return comp?.long_name || null;
       };
 
+      const route = getComponent("route");
+      const city = getComponent("locality") || getComponent("sublocality") || getComponent("administrative_area_level_2");
+      const country = getComponent("country");
+
       return {
-        route: getComponent("route"), // street
-        city: getComponent("locality") || getComponent("sublocality") || getComponent("administrative_area_level_2"),
-        country: getComponent("country"),
-        fullAddress: data.results[0].formatted_address,
+        fullAddress: `${route}, ${city}, ${country}`, // Combined address
+        route,
+        city,
+        country,
       };
     } catch (error) {
       console.error("Error with geocoding:", error);

--- a/client/src/services/api/geocoding.ts
+++ b/client/src/services/api/geocoding.ts
@@ -1,0 +1,51 @@
+import { Alert } from "react-native";
+import { MAPS_PLATFORM_KEY } from "@env";
+
+type AddressComponent = {
+  long_name: string;
+  short_name: string;
+  types: string[];
+};
+
+export const GeocodingApi = {
+  reverseGeocode: async (latitude: number, longitude: number) => {
+    try {
+      const url = new URL("https://maps.googleapis.com/maps/api/geocode/json");
+      url.searchParams.append("latlng", `${latitude},${longitude}`);
+      url.searchParams.append("key", MAPS_PLATFORM_KEY);
+
+      const response = await fetch(url.toString(), {
+        method: "GET",
+        headers: { accept: "application/json" },
+      });
+
+      if (!response.ok) {
+        throw new Error(`API Error: ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      if (!data.results || data.results.length === 0) {
+        throw new Error("No results found for the given coordinates.");
+      }
+
+      const components: AddressComponent[] = data.results[0].address_components;
+
+      const getComponent = (type: string) => {
+        const comp = components.find((c: AddressComponent) => c.types.includes(type));
+        return comp?.long_name || null;
+      };
+
+      return {
+        route: getComponent("route"), // street
+        city: getComponent("locality") || getComponent("sublocality") || getComponent("administrative_area_level_2"),
+        country: getComponent("country"),
+        fullAddress: data.results[0].formatted_address,
+      };
+    } catch (error) {
+      console.error("Error with geocoding:", error);
+      Alert.alert("Geocoding Error", "Failed to reverse geocode the coordinates.");
+      return null;
+    }
+  },
+};

--- a/client/types/env.d.ts
+++ b/client/types/env.d.ts
@@ -2,4 +2,5 @@ declare module '@env' {
   export const SUPABASE_URL: string;
   export const SUPABASE_ANON_KEY: string;
   export const TRIPADVISOR_API_KEY: string;
+  export const MAPS_PLATFORM_KEY: string;
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2083,10 +2083,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.11.tgz#2f4c6e10bee0786abff4604e39a37ded6f3980ce"
   integrity sha512-rQfMIGSR/1r/SyN87+VD8xHHzDYeHaJq6elOSCAD+0iLagXkSI2pfA0LmSXP21uw5i3em7GkkRjfJ8wpqWXZNw==
 
-"@react-native-picker/picker@2.6.1":
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.6.1.tgz#3b20ddd1385fab0487db103dc6519570f8892e6d"
-  integrity sha512-oJftvmLOj6Y6/bF4kPcK6L83yNBALGmqNYugf94BzP0FQGpHBwimVN2ygqkQ2Sn2ZU3pGUZMs0jV6+Gku2GyYg==
+"@react-native-picker/picker@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.11.0.tgz#4587fbce6a382adedad74311e96ee10bb2b2d63a"
+  integrity sha512-QuZU6gbxmOID5zZgd/H90NgBnbJ3VV6qVzp6c7/dDrmWdX8S0X5YFYgDcQFjE3dRen9wB9FWnj2VVdPU64adSg==
 
 "@react-native/assets-registry@0.73.1", "@react-native/assets-registry@~0.73.1":
   version "0.73.1"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2528,6 +2528,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/geojson@^7946.0.13":
+  version "7946.0.16"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
+
 "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -9768,6 +9773,13 @@ react-native-gesture-handler@~2.14.0:
     invariant "^2.2.4"
     lodash "^4.17.21"
     prop-types "^15.7.2"
+
+react-native-maps@^1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.20.1.tgz#f613364886b2f72db56cafcd2bd7d3a35f470dfb"
+  integrity sha512-NZI3B5Z6kxAb8gzb2Wxzu/+P2SlFIg1waHGIpQmazDSCRkNoHNY4g96g+xS0QPSaG/9xRBbDNnd2f2/OW6t6LQ==
+  dependencies:
+    "@types/geojson" "^7946.0.13"
 
 react-native-mmkv@^2.7.0:
   version "2.7.0"


### PR DESCRIPTION
- installed react native maps
- implemented reverse geocoding to convert latlong values from react native map into street, city, country format
- fixed bugs sa initial geocoding api call and location search call na ako nacode
- User can now either use the text box for queries or use the pin to sa map.

Quality of life feature:
- if user types sa text box mawala nag pin and then gamiton ang entry sa text box ipass into sa locationsearch query na call
- if ang user muadd og pin sa map mugray out ang text box nya automatic na siya mahimong street, city, country format and then mapass na into the locationsearch query na call.

this is done to support cases where mangayo lang suggestions ang user sa general area or pwede sad sila muquery og specific locations as in actual name sa place i.e name sa restaurant pwede nila ibutang instead na ang address or city name.

para masabtan lang ang algorithm ako lang iexplain gamay. ang location search naa koy ipass na 2 ka params.

1. kay ang searchquery, it can be a location in general or specific location or place.
2. kay ang category, for now can only support diners and recreation since dili makasupport ang tripadvisor og availability sa hotels and accommodations. though makahatag ra silag accommodation pero walay detail if available ba sila depending sa checkin checkout date since walay checkin checkout date mapass through sa locationsearch request.

sa searchquery ang ipass ana kay whatever ang naa sa text box + iappend ang mga filters sa diners or recreation

sa category ang ipass ana kay diner or recreation

NO UI YET still waiting sa ui design but i think nakuha na nako ang full functionality sa getsuggestions not including the accommodations